### PR TITLE
Add chrome check

### DIFF
--- a/web_ui/src/app/app.component.html
+++ b/web_ui/src/app/app.component.html
@@ -35,16 +35,12 @@
     </div>
 
     <div class="navbar-end">
-      @if (fineVideoService.numPendingTranscodeTasks().pending > 0) {
-        <div
-          class="tooltip tooltip-left"
-          [attr.data-tip]="
-            'Transcoding videos: ' +
-            fineVideoService.numPendingTranscodeTasks().pending.toString() +
-            ' remaining'
-          "
-        >
-          <span class="loading loading-bars loading-xs"></span>
+      @if (!isCompatibleBrowser) {
+        <div role="alert" class="alert alert-warning alert-soft">
+          <span
+            >Browser other than Chrome detected. <br />
+            Switch to Chrome for Labeling and Viewing keypoints.</span
+          >
         </div>
       }
 
@@ -66,18 +62,6 @@
 <div class="fixed top-4 right-4 z-50" aria-live="polite">
   @if (loadingService.isContextLoading()) {
     <span class="loading loading-spinner loading-lg text-primary"></span>
-  }
-  @if (fineVideoService.numPendingTranscodeTasks().pending > 0) {
-    <div
-      class="tooltip tooltip-left"
-      [attr.data-tip]="
-        'Transcoding videos: ' +
-        fineVideoService.numPendingTranscodeTasks().pending.toString() +
-        ' remaining'
-      "
-    >
-      <span class="loading loading-bars loading-xs"></span>
-    </div>
   }
 </div>
 

--- a/web_ui/src/app/app.component.ts
+++ b/web_ui/src/app/app.component.ts
@@ -18,14 +18,13 @@ import {
   RouterLink,
   RouterLinkActive,
   RouterOutlet,
-} from '@angular/router'; // NEW: Import ActivatedRoute, Router
+} from '@angular/router';
 import { ProjectSettingsComponent } from './project-settings/project-settings.component';
 
 import { ProjectInfoService } from './project-info.service';
 import { LoadingService } from './loading.service';
-import { FineVideoService } from './utils/fine-video.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { filter } from 'rxjs/operators'; // NEW: Import filter
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
@@ -40,7 +39,6 @@ import { filter } from 'rxjs/operators'; // NEW: Import filter
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent implements OnInit {
-  protected fineVideoService = inject(FineVideoService);
   protected loadingService = inject(LoadingService);
   protected projectInfoService = inject(ProjectInfoService);
 
@@ -48,8 +46,6 @@ export class AppComponent implements OnInit {
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
 
-  protected projectInfoRequestCompleted = signal(false);
-  protected hasBeenSetup = signal(true);
   protected settingsDialog = viewChild.required<ElementRef>('settingsDialog');
 
   settingsDialogOpen = signal(false);
@@ -70,6 +66,32 @@ export class AppComponent implements OnInit {
       { link: ['/project', key, 'viewer'] as unknown[], text: 'Viewer' },
     ];
   });
+
+  private _isCompatibleBrowser: boolean | null = null;
+  protected get isCompatibleBrowser(): boolean {
+    if (this._isCompatibleBrowser === null) {
+      // @ts-expect-error TS2551
+      if (navigator.userAgentData) {
+        // @ts-expect-error TS2551
+        const brands = navigator.userAgentData.brands;
+
+        // Check specifically for Microsoft Edge
+        const isEdge = brands.some(
+          (b: { brand: string }) => b.brand === 'Microsoft Edge',
+        );
+
+        // Check for the Chromium engine in general (includes Chrome, Edge, Brave, etc.)
+        const isChromium = brands.some(
+          (b: { brand: string }) => b.brand === 'Chromium',
+        );
+
+        this._isCompatibleBrowser = isEdge || isChromium;
+      } else {
+        this._isCompatibleBrowser = false;
+      }
+    }
+    return this._isCompatibleBrowser!;
+  }
 
   constructor() {
     effect(() => {


### PR DESCRIPTION
Users report labeling crosshairs don't render properly in firefox.

I observed that when you zoom in via scrolling in firefox, the issue goes away.

Crosshairs are implemented as 0.5px width lines. These are handled differently in chrome vs firefox. It's not an easy fix - we should funnel users to chrome until we can resolve.

This shows when you are not using chrome (or edge, which is a chrome wrapper):
<img width="737" height="160" alt="image" src="https://github.com/user-attachments/assets/bf020d50-b5a3-4429-9ad3-75934bcf6a14" />
