### PR TITLE
MIT workshop bugfixes

### DIFF
--- a/app_server/src/litpose_app/config_default_multiview.yaml
+++ b/app_server/src/litpose_app/config_default_multiview.yaml
@@ -176,7 +176,7 @@ losses:
   supervised_reprojection_heatmap_mse:
     # actual weight = 1 / (2 * exp(log_weight)); higher values reduce the loss contribution
     # e.g., log_weight=0.0 → weight=0.5, log_weight=3.0 → weight≈0.025
-    log_weight: 3.0
+    log_weight: null  # null disables this loss; only active when camera calibrations are used
 
 eval:
   # predict? used in scripts/train_hydra.py

--- a/web_ui/src/app/create-eks-model-dialog/create-eks-model-dialog.component.html
+++ b/web_ui/src/app/create-eks-model-dialog/create-eks-model-dialog.component.html
@@ -31,10 +31,10 @@
 
       <fieldset class="fieldset my-2">
         <h3 class="text-md mt-0">Member models</h3>
-        <p class="m-0!">Select two or more trained models to ensemble.</p>
+        <p class="m-0!">Select one or more trained models to ensemble.</p>
         @if (availableModels().length === 0) {
           <p class="text-base-content/60 text-sm">
-            No trained models found. Train at least two models first.
+            No trained models found. Train at least one model first.
           </p>
         } @else {
           <div class="flex flex-col gap-1 mt-2">
@@ -55,10 +55,10 @@
           class="my-1! text-error invisible"
           [class.visible!]="
             form.controls.memberIds.touched &&
-            form.controls.memberIds.value.length < 2
+            form.controls.memberIds.value.length < 1
           "
         >
-          Select at least two models
+          Select at least one model
         </p>
       </fieldset>
 
@@ -94,7 +94,7 @@
         class="btn btn-primary"
         (click)="onCreateClick()"
         [class.btn-disabled]="
-          form.invalid || form.controls.memberIds.value.length < 2
+          form.invalid || form.controls.memberIds.value.length < 1
         "
       >
         Create

--- a/web_ui/src/app/create-eks-model-dialog/create-eks-model-dialog.component.spec.ts
+++ b/web_ui/src/app/create-eks-model-dialog/create-eks-model-dialog.component.spec.ts
@@ -1,0 +1,85 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CreateEksModelDialogComponent } from './create-eks-model-dialog.component';
+import { ProjectInfoService } from '../project-info.service';
+import { SessionService } from '../session.service';
+import { ToastService } from '../toast.service';
+import { ModelListResponseEntry } from '../modelconf';
+
+function makeModel(name: string): ModelListResponseEntry {
+  return {
+    model_name: name,
+    model_relative_path: name,
+    model_kind: 'normal',
+    status: { status: 'COMPLETED' },
+  } as ModelListResponseEntry;
+}
+
+describe('CreateEksModelDialogComponent', () => {
+  let component: CreateEksModelDialogComponent;
+  let fixture: ComponentFixture<CreateEksModelDialogComponent>;
+  let mockSessionService: jasmine.SpyObj<SessionService>;
+
+  beforeEach(async () => {
+    mockSessionService = jasmine.createSpyObj('SessionService', [
+      'listModels',
+      'createEksModel',
+    ]);
+    mockSessionService.listModels.and.returnValue(
+      Promise.resolve({ models: [makeModel('model_a'), makeModel('model_b')] }),
+    );
+
+    const mockProjectInfoService = {
+      projectInfo: { views: ['top', 'bot'], keypoint_names: [], data_dir: '', model_dir: '' },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [CreateEksModelDialogComponent],
+      providers: [
+        { provide: SessionService, useValue: mockSessionService },
+        { provide: ProjectInfoService, useValue: mockProjectInfoService },
+        {
+          provide: ToastService,
+          useValue: jasmine.createSpyObj('ToastService', ['showToast']),
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateEksModelDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  function setFormState(modelName: string, memberPaths: string[]) {
+    component['form'].controls.modelName.setValue(modelName);
+    component['form'].controls.memberIds.setValue(memberPaths);
+    fixture.detectChanges();
+  }
+
+  function getCreateButton(): HTMLButtonElement {
+    return fixture.debugElement.query(By.css('button.btn-primary')).nativeElement;
+  }
+
+  describe('Create button disabled state', () => {
+    it('is disabled when 0 models are selected', () => {
+      setFormState('my_eks', []);
+      expect(getCreateButton().classList).toContain('btn-disabled');
+    });
+
+    it('is enabled when 1 model is selected', () => {
+      setFormState('my_eks', ['model_a']);
+      expect(getCreateButton().classList).not.toContain('btn-disabled');
+    });
+
+    it('is enabled when 2 models are selected', () => {
+      setFormState('my_eks', ['model_a', 'model_b']);
+      expect(getCreateButton().classList).not.toContain('btn-disabled');
+    });
+  });
+});

--- a/web_ui/src/app/create-model-dialog/create-model-dialog.component.spec.ts
+++ b/web_ui/src/app/create-model-dialog/create-model-dialog.component.spec.ts
@@ -1,35 +1,116 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import CreateModelDialogComponent from './create-model-dialog.component';
 import { ProjectInfoService } from '../project-info.service';
+import { SessionService } from '../session.service';
+import { CameraCalibrationService } from '../camera-calibration.service';
+import { ToastService } from '../toast.service';
+
+function makeProjectInfoMock(views: string[]) {
+  return {
+    projectInfo: {
+      views,
+      data_dir: '/data',
+      model_dir: '/models',
+      keypoint_names: ['nose', 'tail'],
+    },
+    globalContext: () => null,
+  };
+}
+
+function makeSessionServiceMock() {
+  const mock = jasmine.createSpyObj('SessionService', [
+    'getYamlFile',
+    'getDefaultYamlFile',
+    'getDefaultMultiviewYamlFile',
+    'createTrainingTask',
+  ]);
+  mock.getYamlFile.and.returnValue(Promise.resolve(null));
+  mock.getDefaultYamlFile.and.returnValue(Promise.resolve({}));
+  mock.getDefaultMultiviewYamlFile.and.returnValue(Promise.resolve({}));
+  return mock;
+}
+
+function makeCameraCalibrationServiceMock() {
+  const mock = jasmine.createSpyObj('CameraCalibrationService', [
+    'projectHasCalibrations',
+    'getCalibrationStatus',
+  ]);
+  mock.projectHasCalibrations.and.returnValue(Promise.resolve(false));
+  return mock;
+}
+
+async function createComponent(
+  views: string[],
+): Promise<ComponentFixture<CreateModelDialogComponent>> {
+  await TestBed.configureTestingModule({
+    imports: [CreateModelDialogComponent],
+    providers: [
+      { provide: ProjectInfoService, useValue: makeProjectInfoMock(views) },
+      { provide: SessionService, useValue: makeSessionServiceMock() },
+      {
+        provide: CameraCalibrationService,
+        useValue: makeCameraCalibrationServiceMock(),
+      },
+      {
+        provide: ToastService,
+        useValue: jasmine.createSpyObj('ToastService', ['showToast']),
+      },
+      provideHttpClient(),
+      provideHttpClientTesting(),
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(CreateModelDialogComponent);
+  fixture.detectChanges();
+  return fixture;
+}
 
 describe('CreateModelDialogComponent', () => {
-  let component: CreateModelDialogComponent;
-  let fixture: ComponentFixture<CreateModelDialogComponent>;
-  let mockProjectInfoService: Partial<ProjectInfoService>;
+  it('should create', async () => {
+    const fixture = await createComponent([]);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});
 
-  beforeEach(async () => {
-    mockProjectInfoService = {
-      projectInfo: {
-        views: [],
-        data_dir: '',
-        model_dir: '',
-        keypoint_names: [],
-      } as any,
-    };
+describe('CreateModelDialogComponent — imgaug_3d in config patch', () => {
+  describe('multiview project', () => {
+    let component: CreateModelDialogComponent;
 
-    await TestBed.configureTestingModule({
-      imports: [CreateModelDialogComponent],
-      providers: [
-        { provide: ProjectInfoService, useValue: mockProjectInfoService },
-      ],
-    }).compileComponents();
+    beforeEach(async () => {
+      component = (await createComponent(['top', 'bot'])).componentInstance;
+    });
 
-    fixture = TestBed.createComponent(CreateModelDialogComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    it('sets imgaug_3d to true when calibrations are on', () => {
+      component['useCameraCalibrations'].set(true);
+      const patch = component['computeConfigPatch']({ augmentation: 'dlc' });
+      expect(patch.training?.imgaug_3d).toBe(true);
+    });
+
+    it('sets imgaug_3d to false when calibrations are off', () => {
+      component['useCameraCalibrations'].set(false);
+      const patch = component['computeConfigPatch']({ augmentation: 'dlc' });
+      expect(patch.training?.imgaug_3d).toBe(false);
+    });
+
+    it('sets imgaug_3d even when augmentation is absent from formObject', () => {
+      component['useCameraCalibrations'].set(true);
+      const patch = component['computeConfigPatch']({});
+      expect(patch.training?.imgaug_3d).toBe(true);
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('singleview project', () => {
+    let component: CreateModelDialogComponent;
+
+    beforeEach(async () => {
+      component = (await createComponent(['top'])).componentInstance;
+    });
+
+    it('does not set imgaug_3d', () => {
+      const patch = component['computeConfigPatch']({ augmentation: 'dlc' });
+      expect(patch.training?.imgaug_3d).toBeUndefined();
+    });
   });
 });

--- a/web_ui/src/app/create-model-dialog/create-model-dialog.component.spec.ts
+++ b/web_ui/src/app/create-model-dialog/create-model-dialog.component.spec.ts
@@ -74,6 +74,12 @@ describe('CreateModelDialogComponent', () => {
   });
 });
 
+const MULTIVIEW_LOSSES_ON = {
+  multiviewLosses: {
+    supervised_reprojection_heatmap_mse: { enabled: true, logWeight: 3.0 },
+  },
+};
+
 describe('CreateModelDialogComponent — imgaug_3d in config patch', () => {
   describe('multiview project', () => {
     let component: CreateModelDialogComponent;
@@ -111,6 +117,51 @@ describe('CreateModelDialogComponent — imgaug_3d in config patch', () => {
     it('does not set imgaug_3d', () => {
       const patch = component['computeConfigPatch']({ augmentation: 'dlc' });
       expect(patch.training?.imgaug_3d).toBeUndefined();
+    });
+  });
+});
+
+describe('CreateModelDialogComponent — reprojection loss in config patch', () => {
+  describe('multiview project', () => {
+    let component: CreateModelDialogComponent;
+
+    beforeEach(async () => {
+      component = (await createComponent(['top', 'bot'])).componentInstance;
+    });
+
+    it('includes reprojection log_weight when calibrations are on and loss is enabled', () => {
+      component['useCameraCalibrations'].set(true);
+      const patch = component['computeConfigPatch'](MULTIVIEW_LOSSES_ON);
+      expect(patch.losses?.supervised_reprojection_heatmap_mse?.log_weight).toBe(3.0);
+    });
+
+    it('omits reprojection log_weight when calibrations are off', () => {
+      component['useCameraCalibrations'].set(false);
+      const patch = component['computeConfigPatch'](MULTIVIEW_LOSSES_ON);
+      expect(patch.losses?.supervised_reprojection_heatmap_mse).toBeUndefined();
+    });
+
+    it('omits reprojection log_weight when loss is disabled', () => {
+      component['useCameraCalibrations'].set(true);
+      const patch = component['computeConfigPatch']({
+        multiviewLosses: {
+          supervised_reprojection_heatmap_mse: { enabled: false, logWeight: 3.0 },
+        },
+      });
+      expect(patch.losses?.supervised_reprojection_heatmap_mse).toBeUndefined();
+    });
+  });
+
+  describe('singleview project', () => {
+    let component: CreateModelDialogComponent;
+
+    beforeEach(async () => {
+      component = (await createComponent(['top'])).componentInstance;
+    });
+
+    it('omits reprojection log_weight regardless of loss form values', () => {
+      const patch = component['computeConfigPatch'](MULTIVIEW_LOSSES_ON);
+      expect(patch.losses?.supervised_reprojection_heatmap_mse).toBeUndefined();
     });
   });
 });

--- a/web_ui/src/app/create-model-dialog/create-model-dialog.component.ts
+++ b/web_ui/src/app/create-model-dialog/create-model-dialog.component.ts
@@ -560,6 +560,7 @@ class CreateModelDialogComponent {
         },
       });
     }
+    // imgaug_3d is a 3D augmentation that requires calibration — patch independently of imgaug
     if (this.isMultiviewProject()) {
       patches.push({ training: { imgaug_3d: this.useCameraCalibrations() } });
     }
@@ -578,7 +579,7 @@ class CreateModelDialogComponent {
         });
       }
     }
-    if (this.isMultiviewProject()) {
+    if (this.isMultiviewProject() && this.useCameraCalibrations()) {
       const srphmse =
         formObject.multiviewLosses?.supervised_reprojection_heatmap_mse;
       if (srphmse?.enabled && srphmse.logWeight != null) {

--- a/web_ui/src/app/create-model-dialog/create-model-dialog.component.ts
+++ b/web_ui/src/app/create-model-dialog/create-model-dialog.component.ts
@@ -559,10 +559,9 @@ class CreateModelDialogComponent {
           imgaug: formObject.augmentation as TrainingConfig['imgaug'],
         },
       });
-      if (this.isMultiviewProject()) {
-        const useCalib = this.useCameraCalibrations();
-        patches.push({ training: { imgaug_3d: useCalib } });
-      }
+    }
+    if (this.isMultiviewProject()) {
+      patches.push({ training: { imgaug_3d: this.useCameraCalibrations() } });
     }
 
     if (!this.isMultiviewProject()) {


### PR DESCRIPTION
  Three related fixes to model creation:

  1. EKS ensemble now accepts a single member model
  Relaxed the minimum member count from 2 to 1. This unblocks users who want to apply EKS smoothing
  to a single model's predictions.

  2. imgaug_3d always patched for multiview projects
  imgaug_3d was nested inside the augmentation block in computeConfigPatch, so it was structurally
  coupled to the augmentation form field. It's now patched independently, ensuring it's explicitly
  set to false when calibrations are turned off rather than relying on the base config default.

  3. Reprojection loss only written to config when calibrations are active
  supervised_reprojection_heatmap_mse.log_weight was being patched for all multiview projects
  regardless of the calibrations toggle. This caused lightning_pose validation to fail (imgaug_3d
  must be true when reprojection loss is active) when a user created a multiview model without
  calibrations. The patch is now guarded by useCameraCalibrations(), and the default config value is
  set to null so the loss is inactive unless the user explicitly enables calibrations.

Tests added for all three fixes.